### PR TITLE
Reviewed the dependencies

### DIFF
--- a/examples/react-with-vite-on-cloudflare/package-lock.json
+++ b/examples/react-with-vite-on-cloudflare/package-lock.json
@@ -23,7 +23,7 @@
         "@types/react-dom": "^18.0.9",
         "@vitejs/plugin-react": "^3.0.0",
         "autoprefixer": "^10.4.13",
-        "cloudflare-pages-plugin-trpc": "0.1.1",
+        "cloudflare-pages-plugin-trpc": "0.1.2",
         "postcss": "^8.4.20",
         "tailwindcss": "^3.2.4",
         "typescript": "^4.9.3",
@@ -1171,13 +1171,12 @@
       }
     },
     "node_modules/cloudflare-pages-plugin-trpc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/cloudflare-pages-plugin-trpc/-/cloudflare-pages-plugin-trpc-0.1.1.tgz",
-      "integrity": "sha512-bTQPwrBMPAKu5MMYSbM6i1x2FVU4S1lo8T2ta2oePm8yembENF1982M9A6PXdaPK2r4r62stW3Mt7v3eRURzig==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cloudflare-pages-plugin-trpc/-/cloudflare-pages-plugin-trpc-0.1.2.tgz",
+      "integrity": "sha512-bABKOewrrZqf0jkI2U5XWk5y8nFGjsi74T0PG0vS24Su0Zb1mFVNRbX8DfPo64yX5LuyFRvZ8k85aQ8leYvggg==",
       "dev": true,
-      "dependencies": {
-        "@trpc/server": "10.6.0",
-        "zod": "^3.17.3"
+      "peerDependencies": {
+        "@trpc/server": "10.6.0"
       }
     },
     "node_modules/color-convert": {
@@ -2944,14 +2943,11 @@
       }
     },
     "cloudflare-pages-plugin-trpc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/cloudflare-pages-plugin-trpc/-/cloudflare-pages-plugin-trpc-0.1.1.tgz",
-      "integrity": "sha512-bTQPwrBMPAKu5MMYSbM6i1x2FVU4S1lo8T2ta2oePm8yembENF1982M9A6PXdaPK2r4r62stW3Mt7v3eRURzig==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cloudflare-pages-plugin-trpc/-/cloudflare-pages-plugin-trpc-0.1.2.tgz",
+      "integrity": "sha512-bABKOewrrZqf0jkI2U5XWk5y8nFGjsi74T0PG0vS24Su0Zb1mFVNRbX8DfPo64yX5LuyFRvZ8k85aQ8leYvggg==",
       "dev": true,
-      "requires": {
-        "@trpc/server": "10.6.0",
-        "zod": "^3.17.3"
-      }
+      "requires": {}
     },
     "color-convert": {
       "version": "1.9.3",

--- a/examples/react-with-vite-on-cloudflare/package.json
+++ b/examples/react-with-vite-on-cloudflare/package.json
@@ -25,7 +25,7 @@
     "@types/react-dom": "^18.0.9",
     "@vitejs/plugin-react": "^3.0.0",
     "autoprefixer": "^10.4.13",
-    "cloudflare-pages-plugin-trpc": "0.1.1",
+    "cloudflare-pages-plugin-trpc": "0.1.2",
     "postcss": "^8.4.20",
     "tailwindcss": "^3.2.4",
     "typescript": "^4.9.3",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "license": "MIT",
   "devDependencies": {
     "@cloudflare/workers-types": "^3.8.0",
+    "@trpc/server": "10.6.0",
     "esbuild": "^0.14.46",
     "vitest": "^0.15.1",
     "wrangler": "^2.0.3"
   },
-  "dependencies": {
-    "@trpc/server": "10.6.0",
-    "zod": "^3.17.3"
+  "peerDependencies": {
+    "@trpc/server": "10.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-pages-plugin-trpc",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cloudflare page plugin for tRPC",
   "main": "dist/index.js",
   "types": "index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,14 +6,10 @@ specifiers:
   esbuild: ^0.14.46
   vitest: ^0.15.1
   wrangler: ^2.0.3
-  zod: ^3.17.3
-
-dependencies:
-  '@trpc/server': 10.6.0
-  zod: 3.17.3
 
 devDependencies:
   '@cloudflare/workers-types': 3.13.0
+  '@trpc/server': 10.6.0
   esbuild: 0.14.47
   vitest: 0.15.2
   wrangler: 2.0.15
@@ -199,7 +195,7 @@ packages:
 
   /@trpc/server/10.6.0:
     resolution: {integrity: sha512-SXqogi536yDpfK0xsCaLvP0bzu5Qzn2rRHVr59NJ0SLwLPPKFjfHIrS+O+QnTA3TVUXvnXG0/Hllu8SJXOm7Zg==}
-    dev: false
+    dev: true
 
   /@types/chai-subset/1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
@@ -1090,7 +1086,3 @@ packages:
       mustache: 4.2.0
       stack-trace: 0.0.10
     dev: true
-
-  /zod/3.17.3:
-    resolution: {integrity: sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==}
-    dev: false


### PR DESCRIPTION
issue: #2 

> I would suggest a few other things (let me know if this should be split into different issues):
>
> Move the @trpc/server deps into devDependencies, since you only need this in dev
> Add another peerDependencies section, and add @trpc/server into it. This is so the client project will need to install both @trpc/server and this client.
>  Doing this will make it less likely to break when there are different versions of @trpc/server inside the same project creating a mismatch of types.
> 
> This is what happens when my project already has @trpc/server v10.5.0 and your plugin has v10.6.0. Basically a type mismatch between trpc versions. This goes away when I install @trpc/server in my project to v10.6.0.

I've reviewed the dependencies and removed the package that it's not using. I've also used `peerDependencies` to describe the packages on which this package depends.